### PR TITLE
issue #25

### DIFF
--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -317,7 +317,7 @@ angular.module('ui.scroll', [])
 											clipTop()
 											for item in result
 												newItems.push (insert ++next, item)
-										#log "appended: requested #{bufferSize} received #{result.length} buffer size #{buffer.length} first #{first} next #{next}"
+											#log "appended: requested #{bufferSize} received #{result.length} buffer size #{buffer.length} first #{first} next #{next}"
 										finalize(rid, scrolling, newItems)
 
 							else
@@ -337,7 +337,7 @@ angular.module('ui.scroll', [])
 											clipBottom() if buffer.length
 											for i in [result.length-1..0]
 												newItems.unshift (insert --first, result[i])
-										#log "prepended: requested #{bufferSize} received #{result.length} buffer size #{buffer.length} first #{first} next #{next}"
+											#log "prepended: requested #{bufferSize} received #{result.length} buffer size #{buffer.length} first #{first} next #{next}"
 										finalize(rid, scrolling, newItems)
 
 						resizeHandler = ->


### PR DESCRIPTION
It's update for ng-scroller of 2014.03.29 version (https://github.com/Hill30/NGScroller/blob/0f3384506fa24ba3269e3e25944993c024cc80f6/src/scripts/ui-scroll.coffee) wich solves race condition after-effect. Before promises try.

note: "others by reverting" commit is for apply useful environment changes in main repo from 2014.03.29
