### PR TITLE
Prevent unwanted scroll bubbling

### DIFF
--- a/src/examples/scrollBubblingPrevent.coffee
+++ b/src/examples/scrollBubblingPrevent.coffee
@@ -4,8 +4,8 @@ angular.module('application', ['ui.scroll', 'ui.scroll.jqlite'])
 
 			(console, $timeout)->
 
-				min = -30
-				max = 30
+				min = -50
+				max = 50
 
 				get = (index, count, success)->
 					$timeout(

--- a/src/examples/scrollBubblingPrevent.coffee
+++ b/src/examples/scrollBubblingPrevent.coffee
@@ -12,7 +12,7 @@ angular.module('application', ['ui.scroll', 'ui.scroll.jqlite'])
 						->
 							result = []
 							for i in [index..index + count-1]
-								if i <= min or i >= max
+								if i < min or i > max
 									break
 								result.push "item ##{i}"
 							success(result)

--- a/src/examples/scrollBubblingPrevent.coffee
+++ b/src/examples/scrollBubblingPrevent.coffee
@@ -4,8 +4,8 @@ angular.module('application', ['ui.scroll', 'ui.scroll.jqlite'])
 
 			(console, $timeout)->
 
-				min = -50
-				max = 50
+				min = -30
+				max = 30
 
 				get = (index, count, success)->
 					$timeout(

--- a/src/examples/scrollBubblingPrevent.coffee
+++ b/src/examples/scrollBubblingPrevent.coffee
@@ -1,0 +1,29 @@
+angular.module('application', ['ui.scroll', 'ui.scroll.jqlite'])
+	.factory( 'datasource',
+		[ '$log', '$timeout'
+
+			(console, $timeout)->
+
+				min = -50
+				max = 50
+
+				get = (index, count, success)->
+					$timeout(
+						->
+							result = []
+							for i in [index..index + count-1]
+								if i <= min or i >= max
+									break
+								result.push "item ##{i}"
+							success(result)
+						50
+					)
+
+				{get}
+
+		])
+angular.bootstrap(document, ["application"])
+
+###
+//# sourceURL=src/scripts/listScroller.js
+###

--- a/src/examples/scrollBubblingPrevent.coffee
+++ b/src/examples/scrollBubblingPrevent.coffee
@@ -25,5 +25,5 @@ angular.module('application', ['ui.scroll', 'ui.scroll.jqlite'])
 angular.bootstrap(document, ["application"])
 
 ###
-//# sourceURL=src/scripts/listScroller.js
+//# sourceURL=src/scripts/scrollBubblingPrevent.js
 ###

--- a/src/examples/scrollBubblingPrevent.html
+++ b/src/examples/scrollBubblingPrevent.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Scroller Demo (scroll bubbling prevent) </title>
+    <script src="http://coffeescript.org/extras/coffee-script.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular.js"></script>
+    <script src="../scripts/ui-scroll.coffee" type="text/coffeescript"></script>
+    <script src="../scripts/ui-scroll-jqlite.coffee" type="text/coffeescript"></script>
+    <script src="listScroller.coffee" type="text/coffeescript"></script>
+</head>
+<body>
+<h2 style="position: fixed; left: 150px; top: 0;">is loading: {{loading}}; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="../index.html"> browse sample code</a></h2>
+<h2> Scroll bubbling prevent </h2>
+
+<div style="width: 400px; background-color: rgba(255, 249, 0, 0.28); ">
+
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+
+    <div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;">
+        <ul>
+            <li ui-scroll="item in datasource"  is-loading="loading">*{{item}}*</li>
+        </ul>
+    </div>
+
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+    text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>
+
+</div>
+
+</body>
+</html>

--- a/src/examples/scrollBubblingPrevent.html
+++ b/src/examples/scrollBubblingPrevent.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 <h2> Scroll bubbling prevent </h2>
+There are +/- 30 elements in datasource. Scroll of document begins after bof/eof receiving.
 
 <div style="width: 400px; background-color: rgba(255, 249, 0, 0.28); ">
 

--- a/src/examples/scrollBubblingPrevent.html
+++ b/src/examples/scrollBubblingPrevent.html
@@ -10,7 +10,6 @@
     <script src="listScroller.coffee" type="text/coffeescript"></script>
 </head>
 <body>
-<h2 style="position: fixed; left: 150px; top: 0;">is loading: {{loading}}; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="../index.html"> browse sample code</a></h2>
 <h2> Scroll bubbling prevent </h2>
 
 <div style="width: 400px; background-color: rgba(255, 249, 0, 0.28); ">

--- a/src/examples/scrollBubblingPrevent.html
+++ b/src/examples/scrollBubblingPrevent.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2> Scroll bubbling prevent </h2>
-There are +/- 30 elements in datasource. Scroll of document begins after bof/eof receiving.
+There are +/- 50 elements in datasource. Scroll of document begins after bof/eof receiving.
 
 <div style="width: 400px; background-color: rgba(255, 249, 0, 0.28); ">
 

--- a/src/examples/scrollBubblingPrevent.html
+++ b/src/examples/scrollBubblingPrevent.html
@@ -7,7 +7,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular.js"></script>
     <script src="../scripts/ui-scroll.coffee" type="text/coffeescript"></script>
     <script src="../scripts/ui-scroll-jqlite.coffee" type="text/coffeescript"></script>
-    <script src="listScroller.coffee" type="text/coffeescript"></script>
+    <script src="scrollBubblingPrevent.coffee" type="text/coffeescript"></script>
 </head>
 <body>
 <h2> Scroll bubbling prevent </h2>
@@ -19,7 +19,7 @@
 
     <div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;">
         <ul>
-            <li ui-scroll="item in datasource"  is-loading="loading">*{{item}}*</li>
+            <li ui-scroll="item in datasource">*{{item}}*</li>
         </ul>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
     <li><a href="examples/customviewport.html">Independent scrollable lists</a></li>
     <li><a href="examples/listScroller.html">li based scrollable lists</a></li>
     <li><a href="examples/tableScroller.html">table based scrollable lists</a></li>
-    <li><a href="examples/scrollBubblingPrevent.html">table based scrollable lists</a></li>
+    <li><a href="examples/scrollBubblingPrevent.html">Scroll bubbling prevent test stand</a></li>
 </ul>
 <a href="http://github.com/Hill30/NGScroller/">read more...</a>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
     <li><a href="examples/customviewport.html">Independent scrollable lists</a></li>
     <li><a href="examples/listScroller.html">li based scrollable lists</a></li>
     <li><a href="examples/tableScroller.html">table based scrollable lists</a></li>
-    <li><a href="examples/scrollBubblingPrevent.html">Scroll bubbling prevent test stand</a></li>
+    <li><a href="examples/scrollBubblingPrevent.html">Scroll bubbling prevent demo</a></li>
 </ul>
 <a href="http://github.com/Hill30/NGScroller/">read more...</a>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
     <li><a href="examples/customviewport.html">Independent scrollable lists</a></li>
     <li><a href="examples/listScroller.html">li based scrollable lists</a></li>
     <li><a href="examples/tableScroller.html">table based scrollable lists</a></li>
+    <li><a href="examples/scrollBubblingPrevent.html">table based scrollable lists</a></li>
 </ul>
 <a href="http://github.com/Hill30/NGScroller/">read more...</a>
 </body>

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -359,7 +359,7 @@ angular.module('ui.scroll', [])
 							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
 								e.preventDefault()
 
-						viewport.parent().bind 'DOMMouseScroll', wheelHandler
+						viewport.parent().bind 'mousewheel', wheelHandler
 
 						$scope.$watch datasource.revision,
 							-> reload()
@@ -373,7 +373,7 @@ angular.module('ui.scroll', [])
 							eventListener.$destroy()
 							viewport.unbind 'resize', resizeHandler
 							viewport.unbind 'scroll', scrollHandler
-							viewport.parent().unbind 'DOMMouseScroll', wheelHandler
+							viewport.parent().unbind 'mousewheel', wheelHandler
 
 						eventListener.$on "update.items", (event, locator, newItem)->
 							if angular.isFunction locator

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -359,7 +359,7 @@ angular.module('ui.scroll', [])
 							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
 								e.preventDefault()
 
-						viewport.parent().bind 'mousewheel DOMMouseScroll', wheelHandler
+						viewport.parent().bind 'DOMMouseScroll', wheelHandler
 
 						$scope.$watch datasource.revision,
 							-> reload()
@@ -373,7 +373,7 @@ angular.module('ui.scroll', [])
 							eventListener.$destroy()
 							viewport.unbind 'resize', resizeHandler
 							viewport.unbind 'scroll', scrollHandler
-							viewport.parent().unbind 'mousewheel DOMMouseScroll', wheelHandler
+							viewport.parent().unbind 'DOMMouseScroll', wheelHandler
 
 						eventListener.$on "update.items", (event, locator, newItem)->
 							if angular.isFunction locator

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -359,7 +359,7 @@ angular.module('ui.scroll', [])
 							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
 								e.preventDefault()
 
-						viewport.parent().bind 'mousewheel', wheelHandler
+						viewport.parent().bind 'mousewheel DOMMouseScroll', wheelHandler
 
 						$scope.$watch datasource.revision,
 							-> reload()
@@ -373,7 +373,7 @@ angular.module('ui.scroll', [])
 							eventListener.$destroy()
 							viewport.unbind 'resize', resizeHandler
 							viewport.unbind 'scroll', scrollHandler
-							viewport.parent().unbind 'mousewheel', wheelHandler
+							viewport.parent().unbind 'mousewheel DOMMouseScroll', wheelHandler
 
 						eventListener.$on "update.items", (event, locator, newItem)->
 							if angular.isFunction locator

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -353,12 +353,13 @@ angular.module('ui.scroll', [])
 
 						viewport.bind 'scroll', scrollHandler
 
-						wheelHandler = (e) ->
-							if !(bof and viewport[0].scrollTop is 0) and !(eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight))
-								e.preventDefault()
-								e.stopPropagation()
+						wheelHandler = (event) ->
+							scrollTop = viewport[0].scrollTop
+							yMax = viewport[0].scrollHeight - viewport[0].offsetHeight
+							if (scrollTop is 0 and not bof) or (scrollTop is yMax and not eof)
+								event.preventDefault()
 
-						viewport.parent().bind 'mousewheel', wheelHandler
+						viewport.bind 'mousewheel', wheelHandler
 
 						$scope.$watch datasource.revision,
 							-> reload()
@@ -372,7 +373,7 @@ angular.module('ui.scroll', [])
 							eventListener.$destroy()
 							viewport.unbind 'resize', resizeHandler
 							viewport.unbind 'scroll', scrollHandler
-							viewport.parent().unbind 'mousewheel', wheelHandler
+							viewport.unbind 'mousewheel', wheelHandler
 
 						eventListener.$on "update.items", (event, locator, newItem)->
 							if angular.isFunction locator

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -280,7 +280,7 @@ angular.module('ui.scroll', [])
 										break
 
 						adjustBuffer = (rid, scrolling, newItems, finalize)->
-							if newItems
+							if newItems and newItems.length
 								$timeout ->
 									for row in newItems
 										adjustRowHeight row.appended, row.wrapper
@@ -354,14 +354,10 @@ angular.module('ui.scroll', [])
 						viewport.bind 'scroll', scrollHandler
 
 						wheelHandler = (e) ->
-							if !bof and viewport[0].scrollTop is 0
-								e.preventDefault()
-								e.stopPropagation()
-								return false
-							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
-								e.preventDefault()
-								e.stopPropagation()
-								return false
+							return true if (bof and viewport[0].scrollTop is 0) or
+							(eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight))
+							e.preventDefault()
+							e.stopPropagation()
 
 						viewport.parent().bind 'mousewheel', wheelHandler
 

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -354,10 +354,9 @@ angular.module('ui.scroll', [])
 						viewport.bind 'scroll', scrollHandler
 
 						wheelHandler = (e) ->
-							return true if (bof and viewport[0].scrollTop is 0) or
-							(eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight))
-							e.preventDefault()
-							e.stopPropagation()
+							if !(bof and viewport[0].scrollTop is 0) and !(eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight))
+								e.preventDefault()
+								e.stopPropagation()
 
 						viewport.parent().bind 'mousewheel', wheelHandler
 

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -353,6 +353,14 @@ angular.module('ui.scroll', [])
 
 						viewport.bind 'scroll', scrollHandler
 
+						wheelHandler = (e) ->
+							if !bof and viewport[0].scrollTop is 0
+								e.preventDefault()
+							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
+								e.preventDefault()
+
+						viewport.parent().bind 'mousewheel', wheelHandler
+
 						$scope.$watch datasource.revision,
 							-> reload()
 
@@ -365,6 +373,7 @@ angular.module('ui.scroll', [])
 							eventListener.$destroy()
 							viewport.unbind 'resize', resizeHandler
 							viewport.unbind 'scroll', scrollHandler
+							viewport.parent().unbind 'mousewheel', wheelHandler
 
 						eventListener.$on "update.items", (event, locator, newItem)->
 							if angular.isFunction locator

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -280,7 +280,7 @@ angular.module('ui.scroll', [])
 										break
 
 						adjustBuffer = (rid, scrolling, newItems, finalize)->
-							if newItems and newItems.length
+							if newItems
 								$timeout ->
 									for row in newItems
 										adjustRowHeight row.appended, row.wrapper

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -280,7 +280,7 @@ angular.module('ui.scroll', [])
 										break
 
 						adjustBuffer = (rid, scrolling, newItems, finalize)->
-							if newItems
+							if newItems and newItems.length
 								$timeout ->
 									for row in newItems
 										adjustRowHeight row.appended, row.wrapper
@@ -356,8 +356,12 @@ angular.module('ui.scroll', [])
 						wheelHandler = (e) ->
 							if !bof and viewport[0].scrollTop is 0
 								e.preventDefault()
+								e.stopPropagation()
+								return false
 							if !eof and viewport[0].scrollTop is (viewport[0].scrollHeight - viewport[0].offsetHeight)
 								e.preventDefault()
+								e.stopPropagation()
+								return false
 
 						viewport.parent().bind 'mousewheel', wheelHandler
 

--- a/test/ScrollerSpec.js
+++ b/test/ScrollerSpec.js
@@ -118,7 +118,7 @@ describe('uiScroll', function () {
 				scope.$destroy();
 
 				if (cleanupTest) {
-					//cleanupTest($window, scope);
+					cleanupTest($window, scope);
 				}
 			}
 		);
@@ -610,6 +610,11 @@ describe('uiScroll', function () {
             return '<div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;"><ul><li ui-scroll="item in myDatasourceToPreventScrollBubbling" buffer-size="3">{{$index}}: {{item}}</li></ul></div>';
         };
 
+        var documentScrollCount = 0;
+        var incrementDocumentScrollCount = function() {
+            documentScrollCount++;
+        };
+
         it('[full frame] should call get on the datasource 4 (12/3) times + 2 additional times (with empty result)', function() {
             var spy, flush;
             var viewportHeight = buffer * itemHeight;
@@ -623,7 +628,6 @@ describe('uiScroll', function () {
 
             runTest(makeHtml(viewportHeight),
                 function($window, sandbox) {
-                    var documentScrollCount = 0;
                     var scroller = sandbox.find('[ui-scroll-viewport]');
                     var wheelEventElement = scroller[0];
 
@@ -634,9 +638,7 @@ describe('uiScroll', function () {
                         return event;
                     };
 
-                    angular.element(document.body).bind('mousewheel', function (e) {
-                        documentScrollCount++;
-                    });
+                    angular.element(document.body).bind('mousewheel', incrementDocumentScrollCount); //spy for wheel-events bubbling
 
                     //simulate multiple wheel-scroll events within viewport
 
@@ -657,7 +659,9 @@ describe('uiScroll', function () {
                     expect(flush).toThrow(); //the end of data: no load, no prevent
                     expect(documentScrollCount).toBe(1);
 
-                }, null, {
+                }, function() {
+                    angular.element(document.body).unbind('mousewheel', incrementDocumentScrollCount);
+                }, {
                     sandbox: sandbox,
                     sandboxAppend: function (scroller) {
                         sandbox.find('[data-scroller-append]').append(scroller);

--- a/test/ScrollerSpec.js
+++ b/test/ScrollerSpec.js
@@ -625,11 +625,14 @@ describe('uiScroll', function () {
                 function($window, sandbox) {
                     var documentScrollCount = 0;
                     var scroller = sandbox.find('[ui-scroll-viewport]');
+                    var wheelEventElement = scroller[0];
 
-                    var el = scroller[0];
-                    var evt = document.createEvent("MouseEvents");
-                    evt.initEvent('mousewheel', true, true);
-                    evt.wheelDelta = 120;
+                    var getNewWheelEvent = function () {
+                        var event = document.createEvent("MouseEvents");
+                        event.initEvent('mousewheel', true, true);
+                        event.wheelDelta = 120;
+                        return event;
+                    };
 
                     angular.element(document.body).bind('mousewheel', function (e) {
                         documentScrollCount++;
@@ -638,30 +641,21 @@ describe('uiScroll', function () {
                     //simulate multiple wheel-scroll events within viewport
 
                     scroller.scrollTop(0);
-                    el.dispatchEvent(evt);      //mousewheel low-level event
-                    //scroller.trigger('scroll'); //scroll event
-                    flush();
-                    expect(documentScrollCount).toBe(0);
-
-                    scroller.scrollTop(0);
-                    el.dispatchEvent(evt);      //mousewheel low-level event
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //mousewheel low-level event
                     scroller.trigger('scroll'); //scroll event
                     flush();
                     expect(documentScrollCount).toBe(0);
 
                     scroller.scrollTop(0);
-                    el.dispatchEvent(evt);
-                    expect(flush).toThrow();
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //mousewheel low-level event
+                    scroller.trigger('scroll'); //scroll event
+                    flush();
+                    expect(documentScrollCount).toBe(0);
+
+                    scroller.scrollTop(0);
+                    wheelEventElement.dispatchEvent(getNewWheelEvent());
+                    expect(flush).toThrow(); //the end of data: no load, no prevent
                     expect(documentScrollCount).toBe(1);
-
-                    /*
-                    expect(spy.calls.length).toBe(5);
-
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4);
-                    expect(spy.calls[2].args[0]).toBe(-2); //first full
-                    expect(spy.calls[3].args[0]).toBe(-5); //last full
-                    expect(spy.calls[4].args[0]).toBe(-8); //empty*/
 
                 }, null, {
                     sandbox: sandbox,
@@ -672,43 +666,6 @@ describe('uiScroll', function () {
             );
 
         });
-
-
-        /*it('...', function() {
-            var spy, flush;
-            var viewportHeight = buffer * itemHeight;
-
-            inject(function (myDatasourceToPreventScrollBubbling) {
-                spy = spyOn(myDatasourceToPreventScrollBubbling, 'get').andCallThrough();
-            });
-            inject(function ($timeout) {
-                flush = $timeout.flush;
-            });
-
-            runTest(makeHtml(viewportHeight),
-                function($window, sandbox) {
-                    var scroller = sandbox.children();
-                    scroller.scrollTop(0); //first full
-                    scroller.trigger('scroll');
-                    flush();
-                    scroller.scrollTop(0); //last full
-                    scroller.trigger('scroll');
-                    flush();
-                    scroller.scrollTop(0); //empty
-                    scroller.trigger('scroll');
-                    expect(flush).toThrow();
-
-                    expect(spy.calls.length).toBe(5);
-
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4);
-                    expect(spy.calls[2].args[0]).toBe(-2); //first full
-                    expect(spy.calls[3].args[0]).toBe(-5); //last full
-                    expect(spy.calls[4].args[0]).toBe(-8); //empty
-
-                }
-            );
-        });*/
 
     });
 

--- a/test/ScrollerSpec.js
+++ b/test/ScrollerSpec.js
@@ -106,19 +106,23 @@ describe('uiScroll', function () {
 				spyOn($.fn, 'unbind').andCallThrough();
 				runTest(html,
 					function($window) {
-						expect($.fn.bind.calls.length).toBe(2);
+						expect($.fn.bind.calls.length).toBe(3);
 						expect($.fn.bind.calls[0].args[0]).toBe('resize');
 						expect($.fn.bind.calls[0].object[0]).toBe($window);
 						expect($.fn.bind.calls[1].args[0]).toBe('scroll');
 						expect($.fn.bind.calls[1].object[0]).toBe($window);
+						expect($.fn.bind.calls[2].args[0]).toBe('mousewheel');
+						expect($.fn.bind.calls[2].object.prevObject[0]).toBe($window);
 						expect($._data($window, 'events')).toBeDefined();
 					},
 					function($window) {
-						expect($.fn.unbind.calls.length).toBe(2);
+						expect($.fn.unbind.calls.length).toBe(3);
 						expect($.fn.unbind.calls[0].args[0]).toBe('resize');
 						expect($.fn.unbind.calls[0].object[0]).toBe($window);
 						expect($.fn.unbind.calls[1].args[0]).toBe('scroll');
 						expect($.fn.unbind.calls[1].object[0]).toBe($window);
+						expect($.fn.unbind.calls[2].args[0]).toBe('mousewheel');
+						expect($.fn.unbind.calls[2].object.prevObject[0]).toBe($window);
 					}
 				);
 			});

--- a/test/ScrollerSpec.js
+++ b/test/ScrollerSpec.js
@@ -61,13 +61,13 @@ describe('uiScroll', function () {
 			'$log', '$timeout', '$rootScope', function() {
 				return {
 					get: function(index, count, success) {
-                        var result = [];
-                        for (var i = index; i<index+count; i++) {
-                            if (i>-6 && i<=6)
-                                result.push('item' + i);
-                        }
-                        success(result);
-                    }
+						var result = [];
+						for (var i = index; i<index+count; i++) {
+							if (i>-6 && i<=6)
+								result.push('item' + i);
+						}
+						success(result);
+					}
 				};
 			}
 		])
@@ -76,15 +76,15 @@ describe('uiScroll', function () {
 			'$log', '$timeout', '$rootScope', function() {
 				return {
 					get: function(index, count, success) {
-                        var result = [];
-                        for (var i = index; i<index+count; i++) {
-                            if (i<-6 || i>20) {
-                                break;
-                            }
-                            result.push('item' + i);
-                        }
-                        success(result);
-                    }
+						var result = [];
+						for (var i = index; i<index+count; i++) {
+							if (i<-6 || i>20) {
+								break;
+							}
+							result.push('item' + i);
+						}
+						success(result);
+					}
 				};
 			}
 		]);
@@ -100,19 +100,19 @@ describe('uiScroll', function () {
 
 				angular.element(document).find('body').append(sandbox);
 
-                if(options && options.sandboxAppend) {
-                    options.sandboxAppend(scroller);
-                }
-                else {
-                    sandbox.append(scroller);
-                }
+				if(options && options.sandboxAppend) {
+					options.sandboxAppend(scroller);
+				}
+				else {
+					sandbox.append(scroller);
+				}
 
 				$compile(scroller)(scope);
 				scope.$apply();
 
-                if(!options || !options.noFlush) {
-                    $timeout.flush();
-                }
+				if(!options || !options.noFlush) {
+					$timeout.flush();
+				}
 
 				runTest($window, sandbox);
 
@@ -152,9 +152,9 @@ describe('uiScroll', function () {
 						expect($.fn.unbind.calls[2].args[0]).toBe('mousewheel');
 						expect($.fn.unbind.calls[2].object.prevObject[0]).toBe($window);
 					},
-                    {
-                      noFlush: true //empty data-set; nothing to render
-                    }
+					{
+						noFlush: true //empty data-set; nothing to render
+					}
 				);
 			});
 
@@ -172,8 +172,8 @@ describe('uiScroll', function () {
 						expect(angular.element(bottomPadding).css('height')).toBe('0px');
 
 					}, null, {
-                        noFlush: true
-                    }
+						noFlush: true
+					}
 				);
 			});
 
@@ -189,8 +189,8 @@ describe('uiScroll', function () {
 						expect(spy.calls[1].args[0]).toBe(-9);
 
 					}, null, {
-                        noFlush: true
-                    }
+						noFlush: true
+					}
 				);
 			});
 		}

--- a/test/ScrollerSpec.js
+++ b/test/ScrollerSpec.js
@@ -596,28 +596,22 @@ describe('uiScroll', function () {
 
     describe('prevent unwanted scroll bubbling', function () {
 
-        var itemsCount = 12, buffer = 3, itemHeight = 20;
-
         var sandbox = angular.element('<div style="width: 400px; background-color: rgba(255, 249, 0, 0.28); "/>');
         sandbox.append(angular.element('<div data-scroller-pre-append></div>'));
         sandbox.append(angular.element('<div data-scroller-append></div>'));
         sandbox.append(angular.element('<div data-scroller-post-append></div>'));
         sandbox.find('[data-scroller-pre-append]').html('text<br>text<br>text<br>text<br>');
-        //sandbox.find('[data-scroller-pre-append]').html('text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>');
         sandbox.find('[data-scroller-post-append]').html('text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br>text<br></div>');
 
-        var makeHtml = function (viewportHeight) {
-            return '<div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;"><ul><li ui-scroll="item in myDatasourceToPreventScrollBubbling" buffer-size="3">{{$index}}: {{item}}</li></ul></div>';
-        };
+        var commonHtml = '<div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;"><ul><li ui-scroll="item in myDatasourceToPreventScrollBubbling" buffer-size="3">{{$index}}: {{item}}</li></ul></div>';
 
         var documentScrollCount = 0;
         var incrementDocumentScrollCount = function() {
             documentScrollCount++;
         };
 
-        it('[full frame] should call get on the datasource 4 (12/3) times + 2 additional times (with empty result)', function() {
+        it('should prevent some wheel-events (2) until bof is reached and then scroll entire document', function() {
             var spy, flush;
-            var viewportHeight = buffer * itemHeight;
 
             inject(function (myDatasourceToPreventScrollBubbling) {
                 spy = spyOn(myDatasourceToPreventScrollBubbling, 'get').andCallThrough();
@@ -626,7 +620,7 @@ describe('uiScroll', function () {
                 flush = $timeout.flush;
             });
 
-            runTest(makeHtml(viewportHeight),
+            runTest(commonHtml,
                 function($window, sandbox) {
                     var scroller = sandbox.find('[ui-scroll-viewport]');
                     var wheelEventElement = scroller[0];


### PR DESCRIPTION
- it's for <a href="https://github.com/angular-ui/ui-utils/issues/239">issue #239</a> of ui-utils (scrolling over ngScroll intermittently scrolls entire document when bottom of scroll 'page' is reached)
-  i've added a <a href="http://rawgit.com/dhilt/NGScroller/scroll-prevent/src/examples/scrollBubblingPrevent.html">demo</a> (now accessed from <a href="http://rawgit.com/dhilt/NGScroller/scroll-prevent/src/index.html">index</a>)
- <strike>apart from demo i hardly tried but i can't finish tests for scroll/mousewheel bubbling case; the task of mousewheel simulation for tests is not good-explored task... i will retry it later</strike>
- it may looks strange if FF, but this is normal scroll-within-scroll behaviour in that browser
