### PR TITLE
Fix bootstrap's well css class bug (issue #4)

### DIFF
--- a/src/examples/bootstrapWellClass.html
+++ b/src/examples/bootstrapWellClass.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Scroller Demo (bootstrap's well css class) </title>
+    <script src="http://coffeescript.org/extras/coffee-script.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.6/angular.js"></script>
+    <script src="../scripts/ui-scroll.coffee" type="text/coffeescript"></script>
+    <script src="../scripts/ui-scroll-jqlite.coffee" type="text/coffeescript"></script>
+    <script src="customviewport.coffee" type="text/coffeescript"></script>
+
+	<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+	<script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+</head>
+<body>
+
+<h2 style="position: fixed; left: 315px; top: 0;">is loading: {{loading}}; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="../index.html"> browse sample code</a></h2>
+<h2> Bootstraped viewport </h2>
+
+<div ui-scroll-viewport class="well" style="width: 300px; height: 300px;">
+    <div ui-scroll="item in datasource" is-loading="loading" buffer-size='4'>*{{item}}*</div>
+</div>
+
+</body>
+</html>

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -52,7 +52,7 @@ angular.module('ui.scroll', [])
 							throw new Error "#{datasourceName} is not a valid datasource" unless isDatasource datasource
 
 						bufferSize = Math.max(3, +$attr.bufferSize || 10)
-						bufferPadding = -> viewport.height() * Math.max(0.1, +$attr.padding || 0.1) # some extra space to initate preload
+						bufferPadding = -> viewport.outerHeight() * Math.max(0.1, +$attr.padding || 0.1) # some extra space to initate preload
 
 						scrollHeight = (elem)->
 							elem[0].scrollHeight ? elem[0].document.documentElement.scrollHeight
@@ -166,7 +166,7 @@ angular.module('ui.scroll', [])
 							adjustBuffer(ridActual, false)
 
 						bottomVisiblePos = ->
-							viewport.scrollTop() + viewport.height()
+							viewport.scrollTop() + viewport.outerHeight()
 
 						topVisiblePos = ->
 							viewport.scrollTop()
@@ -383,7 +383,7 @@ angular.module('ui.scroll', [])
 
 						wheelHandler = (event) ->
 							scrollTop = viewport[0].scrollTop
-							yMax = viewport[0].scrollHeight - viewport[0].offsetHeight
+							yMax = viewport[0].scrollHeight - viewport[0].clientHeight
 							if (scrollTop is 0 and not bof) or (scrollTop is yMax and not eof)
 								event.preventDefault()
 


### PR DESCRIPTION
Еще раз о замене viewport.height() на viewport.outerHeight().

При расчете bufferPadding и bottomVisiblePos используется высота viewport. Если viewport не стилизован дополнительными отступами и рамками, то для расчета его высоты подходит вариант viewport.height(), поскольку он совпадает с viewport.outerHeight(). Однако применение well-класса добавляет отступы (по 19px) и рамку (по 1px). В этом и была проблема. При расчете же topVisiblePos высота viewpot не используется, поэтому в данном issue мы не видим проблем со скроллом вверх.

И аналогичный момент пришлось учесть при перехвате всплытия события на wheelHandler в моем собственном коде. То есть offsetHeight я заменил на clientHeight, поскольку по спецификации clientHeight в отличие от offsetHeight учитывает рамки. И по результатам отладки (в случае с применением well-класса) именно этих двух пикселей не хватало, чтобы попасть в условие прерывания события.

---

<b>И на счет замены нативных scrollTop, scrollHeight и clientHeight на jquery-аналоги.</b> Исходя из данных <a href="http://www.quirksmode.org/dom/w3c_cssom.html">w3c</a>, проблемы с нативными свойствами есть у ie<=7, а также у кое-каких Опер (непоследних). Так что жесткой необходимости по замене я не вижу. Тем не менее, если мы все же хотим использовать jquery-аналоги, то в ui-scroll-jqlite.coffee необходимо будет добавить метод scrollHeight()... И это должен быть отдельный issue с отдельным pull request, тем более что в настоящее время в мастере NGScroller в части кода по перехвату скролла используются нативные scrollTop и т.д..
