### PR TITLE
Deep access to datasource

### DIFF
--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -47,10 +47,10 @@ angular.module('ui.scroll', [])
 							angular.isObject(datasource) and datasource.get and angular.isFunction(datasource.get)
 
 						getValueChain = (targetScope, target) ->
+							return null if not targetScope
 							chain = target.match(/^([\w]+)\.(.+)$/)
 							return targetScope[target] if not chain or chain.length isnt 3
-							return null if not targetScope.hasOwnProperty(chain[1])
-							getValueChain(targetScope[chain[1]], chain[2])
+							return getValueChain(targetScope[chain[1]], chain[2])
 
 						datasource = getValueChain($scope, datasourceName)
 


### PR DESCRIPTION
This may be helpfull in case of nested controllers. Or just when you have to write something like this:

<code>
  ui-scroll="item in childScopes.myScope.datasource"
</code>

So we need to allow dot-notation and provide mechanism to get datasource through chain properties.
