### PR TITLE
New mechanism of scroller data custom processing (with usage sample)

### DIFF
--- a/src/examples/twoUpdatableLists.coffee
+++ b/src/examples/twoUpdatableLists.coffee
@@ -1,0 +1,43 @@
+angular.module('application', ['ui.scroll', 'ui.scroll.jqlite']).controller('mainController',
+		[ '$scope', '$log', '$timeout'
+
+			($scope, console, $timeout)->
+
+				datasource = {}
+
+				datasource.get = (index, count, success)->
+					$timeout(
+						->
+							result = []
+							for i in [index..index + count-1]
+								item = {}
+								item.content = "item #" + i
+								result.push item
+							success(result)
+						100
+					)
+
+				$scope.datasource =  datasource
+
+				$scope.firstListProcessing = {}
+				$scope.second = {
+					list: {
+						processing: {}
+					}
+				}
+
+				$scope.updateList1 = () ->
+					$scope.firstListProcessing.update (scope) ->
+						scope.item.content += ' upd';
+
+				$scope.updateList2 = () ->
+					$scope.second.list.processing.update (scope) ->
+						scope.item.content += ' upd';
+
+		])
+
+angular.bootstrap(document, ["application"])
+
+###
+//# sourceURL=src/scripts/twoUpdatableLists.js
+###

--- a/src/examples/twoUpdatableLists.html
+++ b/src/examples/twoUpdatableLists.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html ng-app="application">
+<head>
+    <meta charset="utf-8">
+    <title>Scroller Demo (two updatable lists)</title>
+    <script src="http://coffeescript.org/extras/coffee-script.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular.js"></script>
+    <script src="../scripts/ui-scroll.coffee" type="text/coffeescript"></script>
+    <script src="../scripts/ui-scroll-jqlite.coffee" type="text/coffeescript"></script>
+    <script src="twoUpdatableLists.coffee"  type="text/coffeescript"></script>
+</head>
+<body ng-controller="mainController">
+
+<style>
+	a.toggler {
+		cursor: pointer;
+		color: #750000;
+		font-weight: normal;
+	}
+
+	a.toggler:hover {
+		color: red;
+	}
+
+	.note {
+		margin-left: 40px;
+		margin-top: 65px;
+	}
+
+	button {
+		margin-top: 15px;
+	}
+</style>
+
+
+<div style="float: left;">
+	<h2>
+		Local demo
+	</h2>
+
+	<table>
+		<tr>
+			<td>
+				<div ui-scroll-viewport style="height:300px; width: 200px;">
+					<div ui-scroll="item in datasource"
+						 processing="firstListProcessing"
+						 buffer-size='5'>{{item.content}}</div>
+				</div>
+				<button ng-click="updateList1()">update list 1</button>
+			</td>
+			<td>
+				<div style="margin-left: 30px;">
+					<div ui-scroll-viewport style="height:300px; width: 200px; ">
+						<div ui-scroll="item in datasource"
+							 processing="second.list.processing"
+							 buffer-size='5'>{{item.content}}</div>
+					</div>
+					<button ng-click="updateList2()">update list 2</button>
+				</div>
+			</td>
+		</tr>
+	</table>
+</div>
+
+<div style="float: left;" class="note">
+	<p>
+		New mechanism of scroller data custom processing is introduced.
+	</p>
+
+	<p>
+		(c) dhilt, 2014
+	</p>
+</div>
+
+<div style="clear: both;"></div>
+
+
+</body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,8 @@
     <li><a href="examples/scrollBubblingPrevent.html">Scroll bubbles up only on eof/bof</a></li>
     <li><a href="examples/windowviewportInline.html">Inline blocks demo</a></li>
     <li><a href="examples/bootstrapWellClass.html">Bootstrap well-class demo</a></li>
-    <li><a href="examples/cache.html">Cache within datasource implementation</a></li>
+	<li><a href="examples/cache.html">Cache within datasource implementation</a></li>
+	<li><a href="examples/twoUpdatableLists.html">New mechanism of scroller data custom processing</a></li>
 </ul>
 <a href="http://github.com/Hill30/NGScroller/">read more...</a>
 </body>

--- a/src/scripts/ui-scroll.coffee
+++ b/src/scripts/ui-scroll.coffee
@@ -412,7 +412,7 @@ angular.module('ui.scroll', [])
 							viewport.unbind 'scroll', scrollHandler
 							viewport.unbind 'mousewheel', wheelHandler
 
-						eventListener.$on "update.items", (event, locator, newItem)->
+						updateItems = (locator, newItem) ->
 							if angular.isFunction locator
 								((wrapper)->
 									locator wrapper.scope
@@ -422,7 +422,7 @@ angular.module('ui.scroll', [])
 									buffer[locator-first-1].scope[itemName] = newItem
 							null
 
-						eventListener.$on "delete.items", (event, locator)->
+						deleteItems = (locator) ->
 							if angular.isFunction locator
 								temp = []
 								temp.unshift item for item in buffer
@@ -439,7 +439,7 @@ angular.module('ui.scroll', [])
 							item.scope.$index = first + i for item,i in buffer
 							adjustBuffer(null, false)
 
-						eventListener.$on "insert.item", (event, locator, item)->
+						insertItems = (locator, item) ->
 							inserted = []
 							if angular.isFunction locator
 #								temp = []
@@ -462,6 +462,17 @@ angular.module('ui.scroll', [])
 
 							item.scope.$index = first + i for item,i in buffer
 							adjustBuffer(null, false, inserted)
+
+						eventListener.$on "insert.item", (event, locator, item)-> insertItems(locator, item)
+						eventListener.$on "update.items", (event, locator, newItem)-> updateItems(locator, newItem)
+						eventListener.$on "delete.items", (event, locator)-> deleteItems(locator)
+
+						processing = $attr.processing
+						processing = getValueChain($scope, processing)
+						if processing and angular.isObject(processing)
+							processing.insert = insertItems
+							processing.update = updateItems
+							processing.delete = deleteItems
 
 		])
 


### PR DESCRIPTION
A new parameter 'processing' is introduced. It's a name of object in ctrl which will get insert-update-delete methods after ui-scroll compiles.

See the demo http://rawgit.com/dhilt/NGScroller/insert-update-delete/src/examples/twoUpdatableLists.html of two scroller lists which are using the same datasource and the different processing objects.

A minimal changes with backward compatibility.